### PR TITLE
Integrate Tailwind CSS and document design tokens

### DIFF
--- a/DESIGN_TOKENS.md
+++ b/DESIGN_TOKENS.md
@@ -1,0 +1,32 @@
+# Design Tokens
+
+This project uses a small set of design tokens to keep styles consistent.
+
+## Spacing Scale
+
+| Token | Value |
+|-------|-------|
+| `space-1` | `0.25rem` |
+| `space-2` | `0.5rem` |
+| `space-4` | `1rem` |
+| `space-6` | `1.5rem` |
+| `space-12` | `3rem` |
+
+## Font Sizes
+
+| Token | Value |
+|-------|-------|
+| `font-base` | `1rem` |
+| `font-lg` | `1.2rem` |
+| `font-xl` | `clamp(1.5rem, 4vw, 2.5rem)` |
+
+## Color Palette
+
+| Token | Value |
+|-------|-------|
+| `--bg-color` | `#0E0E10` |
+| `--bg-color-alt` | `#121212` |
+| `--text-color` | `#FFFFFF` |
+| `--text-color-muted` | `rgba(255, 255, 255, 0.9)` |
+| `--accent-color` | `#C9A857` |
+

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>מכירת זכות לדירה - נערדיא תיווך, יזמות ונדל״ן</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-dBwexvS0jRW1xjph9fZr2tZWGkyRkVYvNULmKMluSleqU9jwELyhlHLLJoCq114F8C5MD4PlzyBbs6k0XKHZKw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <style>
     /* Dark luxury palette */
     :root {
@@ -34,16 +35,7 @@
       line-height: 1.6;
     }
 
-    .container {
-      width: 100%;
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 0 1rem;
-    }
-
-    section {
-      padding: 3rem 1rem;
-    }
+    /* Layout helpers now handled by Tailwind utility classes */
 
     h1, h2, h3 {
       margin-bottom: 1.5rem;
@@ -74,24 +66,7 @@
       color: var(--accent-color);
     }
 
-    .btn {
-      display: inline-block;
-      background-color: var(--accent-color);
-      color: var(--bg-color);
-      padding: 0.8rem 1.5rem;
-      border-radius: 0.5rem;
-      font-weight: bold;
-      cursor: pointer;
-      transition: var(--transition);
-      text-align: center;
-      border: none;
-    }
-
-    .btn:hover {
-      background-color: #d9b867;
-      transform: translateY(-2px);
-      box-shadow: 0 5px 15px rgba(201, 168, 87, 0.3);
-    }
+    /* Buttons now use Tailwind utility classes */
 
     .card {
       background-color: var(--bg-color-alt);
@@ -728,17 +703,17 @@
   </header>
 
   <main>
-    <section id="hero" class="hero">
+    <section id="hero" class="hero py-12 px-4">
       <div class="hero-content">
         <h1>למכירה — זכות לדירה בשכונה חדשה במזרח ראשון לציון</h1>
         <p>הזדמנות מוקדמת באזור 'משולש נים', בקרבת עזריאלי ראשונים</p>
         <div class="price-badge">מחיר פתיחה: ₪999,000</div>
-        <a href="#lead-form" class="btn">מעוניין בפרטים — חזרה אלי</a>
+        <a href="#lead-form" class="inline-block bg-[var(--accent-color)] text-[var(--bg-color)] py-3 px-6 rounded font-bold transition hover:bg-[#d9b867] hover:-translate-y-0.5 shadow">מעוניין בפרטים — חזרה אלי</a>
       </div>
     </section>
 
-    <section id="highlights" class="highlights reveal">
-      <div class="container">
+    <section id="highlights" class="highlights reveal py-12 px-4">
+      <div class="max-w-6xl mx-auto">
         <h2>יתרונות</h2>
         <div class="highlights-container">
           <div class="highlight">
@@ -765,8 +740,8 @@
       </div>
     </section>
 
-    <section id="area-info" class="area-info reveal">
-      <div class="container">
+    <section id="area-info" class="area-info reveal py-12 px-4">
+      <div class="max-w-6xl mx-auto">
         <h2>על האזור</h2>
         <div class="property-size">כ-170 מ״ר (לאשר סופית מול הנציג)</div>
         <div class="about-area">
@@ -777,8 +752,8 @@
       </div>
     </section>
 
-    <section id="gallery" class="gallery reveal">
-      <div class="container">
+    <section id="gallery" class="gallery reveal py-12 px-4">
+      <div class="max-w-6xl mx-auto">
         <h2>גלריה</h2>
         <div class="gallery-container">
           <div class="gallery-item" data-index="0">
@@ -809,8 +784,8 @@
       </div>
     </section>
 
-    <section id="map" class="map reveal">
-      <div class="container">
+    <section id="map" class="map reveal py-12 px-4">
+      <div class="max-w-6xl mx-auto">
         <h2 class="map-title">המיקום — מזרח ראשון לציון (משולש נים)</h2>
         <div class="map-container">
           <iframe class="map-iframe" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3384.4277075686!2d34.79961!3d31.948!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zMzHCsDU2JzUyLjgiTiAzNMKwNDgnMTAuOCJF!5e0!3m2!1sen!2sil!4v1628000000000!5m2!1sen!2sil" loading="lazy" referrerpolicy="no-referrer-when-downgrade" title="מפת מיקום הפרויקט במזרח ראשון לציון" aria-label="מפת גוגל המציגה את מיקום הפרויקט במזרח ראשון לציון, באזור משולש נים"></iframe>
@@ -818,8 +793,8 @@
       </div>
     </section>
 
-    <section id="lead-form" class="lead-form reveal">
-      <div class="container">
+    <section id="lead-form" class="lead-form reveal py-12 px-4">
+      <div class="max-w-6xl mx-auto">
         <h2>מעוניינים בפרטים נוספים?</h2>
         <div class="form-container">
           <form id="contact-form">
@@ -835,7 +810,7 @@
               <label for="email">אימייל</label>
               <input type="email" id="email" name="email" placeholder="הזינו כתובת אימייל תקינה" required>
             </div>
-            <button type="submit" class="btn submit-btn" disabled>נשמר מקומית בלבד</button>
+            <button type="submit" class="submit-btn inline-block bg-[var(--accent-color)] text-[var(--bg-color)] py-3 px-6 rounded font-bold transition hover:bg-[#d9b867] disabled:opacity-50" disabled>נשמר מקומית בלבד</button>
           </form>
         </div>
       </div>
@@ -843,7 +818,7 @@
   </main>
 
   <footer>
-    <div class="container">
+    <div class="max-w-6xl mx-auto px-4">
       <div class="footer-brand">נערדיא תיווך, יזמות ונדל״ן</div>
       <nav class="footer-nav">
         <ul>


### PR DESCRIPTION
## Summary
- Add Tailwind CSS via CDN and drop custom container/button/section styles
- Replace repeated inline-style equivalents with Tailwind utility classes for layout and buttons
- Document spacing, typography, and color design tokens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ace9caac8322a431a8ccf058afc8